### PR TITLE
adding flexibility for naming convention of constant definition

### DIFF
--- a/RabbitORM/DefinitionReader.php
+++ b/RabbitORM/DefinitionReader.php
@@ -18,9 +18,17 @@ class DefinitionReader {
     }
 
     public function getClassDefinition(ReflectionClass $class) {
-        $jsonDefinition = $class->getConstant($class->getName() . "Definition");
+
+        $jsonDefinition = $this->isDefinitionExist($class, $class->getName());
+
+        if(!$jsonDefinition) $jsonDefinition = $this->isDefinitionExist($class, strtolower($class->getName()));
+
         return json_decode($jsonDefinition);
-   }
+   	}
+
+   	private function isDefinitionExist(ReflectionClass $class, $definition) {
+       return $class->getConstant($definition . "Definition") ?: FALSE;
+   	}
 
 
 }


### PR DESCRIPTION
Got confuse when you talk about "camelCase" or "CamelCase" for naming convention of constant definition inside Model. Let say we named the entities `entities\User.php` and have following code :

```php
<?php

class User extends RabbitORM\Model {

    protected $table = 'users';

    const userDefinition = '{"name": "users", "table": "users"}';

}
```
you will got an error telling about : 

```
Unknown column 'id' in 'field list'
....
Filename: libraries/rabbit-orm/RabbitORM/Result.php
......
```
because of the class's name using Capital Letter in front, so i make this pull request to give user an option whether to name either `UserDefinition` or `userDefinition`. This pull request related to this issue [#3](https://github.com/fabiocmazzo/rabbit-orm/issues/3)
