### PR TITLE
Props and relations can more flexibly be retrieved

### DIFF
--- a/RabbitORM/Model.php
+++ b/RabbitORM/Model.php
@@ -562,7 +562,23 @@ class Model {
 
 	function __get($field)
     {
-    	if(!isset( $this->data[ $field ] )) $value = '';
+		if(!isset( $this->data[ $field ] ))
+		{
+			$value = '';
+			$defField = array_search( $field, $this->propertiesDefinition );
+			if ( $defField !== false && $this->data[ $defField ] )
+			{
+				$value = $this->data[ $defField ];
+			}
+			else
+			{
+				$relation = $this->getRelation( $field );
+				if ( $relation )
+				{
+					return $relation;
+				}
+			}
+		}
 		else
  		$value = $this->data[ $field ];
 


### PR DESCRIPTION
There was an issue with foreign keys in relations where it was unable to link the data. This was because the code assumed that the foreign key was also the property, however, when using a property definition, the property name changes, something the foreign key doesn't take into account.

What this fix does is it tries to resolve the property value based on its original field name, by using the magic method __get and the propertiesDefinition property.

This will also automatically map the relations properly.